### PR TITLE
Add invoices prop to ChartCard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -593,7 +593,11 @@ const handleDownloadSale = async (sale: any) => {
             {/* Dashboard Content */}
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
               <div className="lg:col-span-2 space-y-6">
-                <ChartCard sales={sales} expenses={expenses} />
+                <ChartCard
+                  sales={sales}
+                  expenses={expenses}
+                  invoices={invoices}
+                />
                 <div className="bg-white rounded-lg shadow-sm p-6">
                   <h3 className="text-lg font-semibold text-gray-900 mb-4">Hızlı Erişim</h3>
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary
- pass dashboard invoice data into ChartCard so its charts can include paid invoices

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0733b247c833085cbf47c957edad0