### PR TITLE
Improve currency parsing and add numeric parsing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist-tests/

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "tsc -p tsconfig.test.json && node --experimental-specifier-resolution=node dist-tests/number.test.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/utils/number.js.d.ts
+++ b/src/utils/number.js.d.ts
@@ -1,0 +1,3 @@
+declare module './number.js' {
+  export * from './number';
+}

--- a/src/utils/number.test.ts
+++ b/src/utils/number.test.ts
@@ -1,0 +1,41 @@
+import { normaliseNumericString, parseCurrencyToNumber } from './number.js';
+
+const strictEqual = (actual: unknown, expected: unknown, message?: string) => {
+  if (actual !== expected) {
+    throw new Error(message ?? `Expected ${String(actual)} to strictly equal ${String(expected)}`);
+  }
+};
+
+const approximatelyEqual = (actual: number, expected: number, epsilon = 1e-9) => {
+  if (Number.isNaN(actual) || Math.abs(actual - expected) > epsilon) {
+    throw new Error(`Expected ${actual} to be within ${epsilon} of ${expected}`);
+  }
+};
+
+const normalisationCases: Array<{ input: string; expected: string }> = [
+  { input: '0.123', expected: '0.123' },
+  { input: '0,123', expected: '0.123' },
+  { input: '-0,123', expected: '-0.123' },
+  { input: '1.234', expected: '1234' },
+  { input: '12,345', expected: '12345' },
+];
+
+normalisationCases.forEach(({ input, expected }) => {
+  const actual = normaliseNumericString(input);
+  strictEqual(actual, expected, `normaliseNumericString(${input}) should be ${expected}`);
+});
+
+const parsingCases: Array<{ input: string; expected: number }> = [
+  { input: '0.123', expected: 0.123 },
+  { input: '0,123', expected: 0.123 },
+  { input: '-0,123', expected: -0.123 },
+  { input: '1.234', expected: 1234 },
+  { input: '12,345', expected: 12345 },
+];
+
+parsingCases.forEach(({ input, expected }) => {
+  const actual = parseCurrencyToNumber(input);
+  approximatelyEqual(actual, expected);
+});
+
+console.log('All number utility tests passed.');

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,16 +1,139 @@
+const sanitizeNumericInput = (value: unknown): string => {
+  const raw = String(value ?? '')
+    .trim()
+    .replace(/\s+/g, '')
+    .replace(/[^0-9,.+-]/g, '');
+
+  if (!raw) return '';
+
+  const hasLeadingMinus = raw.startsWith('-');
+  const sanitized = raw.replace(/[+-]/g, '');
+
+  if (!sanitized) return hasLeadingMinus ? '-' : '';
+
+  return hasLeadingMinus ? `-${sanitized}` : sanitized;
+};
+
+const hasThousandSeparators = (value: string): boolean => {
+  const unsigned = value.replace(/^[+-]/, '');
+  const separators = unsigned.match(/[.,]/g);
+
+  if (!separators) return false;
+
+  const uniqueSeparators = new Set(separators);
+
+  if (uniqueSeparators.size > 1) {
+    return true;
+  }
+
+  const separator = separators[0];
+  const parts = unsigned.split(separator);
+
+  if (parts.length <= 1) return false;
+
+  if (parts.length === 2) {
+    const [integerPart, fractionalPart] = parts;
+    const integerDigits = integerPart.replace(/\D/g, '');
+
+    if (!integerDigits || Number(integerDigits) === 0) {
+      return false;
+    }
+
+    return fractionalPart.length === 3;
+  }
+
+  return parts.slice(1).every((group) => group.length === 3);
+};
+
+type DecimalSeparator = '.' | ',' | null;
+
+const determineDecimalSeparator = (
+  value: string,
+  thousandSeparated: boolean,
+): DecimalSeparator => {
+  const unsigned = value.replace(/^[+-]/, '');
+  const lastDot = unsigned.lastIndexOf('.');
+  const lastComma = unsigned.lastIndexOf(',');
+
+  if (lastDot === -1 && lastComma === -1) {
+    return null;
+  }
+
+  if (lastDot !== -1 && lastComma !== -1) {
+    return lastDot > lastComma ? '.' : ',';
+  }
+
+  if (!thousandSeparated) {
+    return lastDot !== -1 ? '.' : ',';
+  }
+
+  return null;
+};
+
+const determineThousandSeparator = (
+  value: string,
+  decimalSeparator: DecimalSeparator,
+  thousandSeparated: boolean,
+): '.' | ',' | null => {
+  if (!thousandSeparated) return null;
+
+  const unsigned = value.replace(/^[+-]/, '');
+  const separators = unsigned.match(/[.,]/g) as Array<'.' | ','> | null;
+
+  if (!separators || separators.length === 0) return null;
+
+  const uniqueSeparators = Array.from(new Set(separators)) as Array<'.' | ','>;
+
+  if (decimalSeparator) {
+    return uniqueSeparators.find((separator) => separator !== decimalSeparator) ?? null;
+  }
+
+  return uniqueSeparators[0] ?? null;
+};
+
+export const normaliseNumericString = (value: unknown): string => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value.toString() : '0';
+  }
+
+  const sanitized = sanitizeNumericInput(value);
+
+  if (!sanitized || sanitized === '-') {
+    return '0';
+  }
+
+  const thousandSeparated = hasThousandSeparators(sanitized);
+  const decimalSeparator = determineDecimalSeparator(sanitized, thousandSeparated);
+  const thousandSeparator = determineThousandSeparator(
+    sanitized,
+    decimalSeparator,
+    thousandSeparated,
+  );
+
+  let normalized = sanitized;
+
+  if (thousandSeparator) {
+    const thousandRegex = new RegExp(`\\${thousandSeparator}`, 'g');
+    normalized = normalized.replace(thousandRegex, '');
+  }
+
+  if (decimalSeparator && decimalSeparator !== '.') {
+    const decimalRegex = new RegExp(`\\${decimalSeparator}`, 'g');
+    normalized = normalized.replace(decimalRegex, '.');
+  }
+
+  return normalized;
+};
+
 export const parseCurrencyToNumber = (value: unknown): number => {
-  if (typeof value === 'number') return value;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+
   if (value == null) return 0;
 
-  const sanitized = String(value)
-    .trim()
-    .replace(/\s/g, '')
-    .replace(/[^\d,.-]/g, '');
-
-  if (!sanitized) return 0;
-
-  const normalized = sanitized.replace(/\./g, '').replace(/,/g, '.');
-  const parsed = parseFloat(normalized);
+  const normalized = normaliseNumericString(value);
+  const parsed = Number.parseFloat(normalized);
 
   return Number.isNaN(parsed) ? 0 : parsed;
 };

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist-tests",
+    "allowImportingTsExtensions": false
+  },
+  "include": [
+    "src/utils/number.ts",
+    "src/utils/number.test.ts",
+    "src/utils/number.js.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- refine the numeric parsing utilities to distinguish decimal inputs with a zero integer part from thousand-separated values
- expose a `normaliseNumericString` helper and add lightweight unit tests covering decimal and thousand-separated scenarios
- add a dedicated TypeScript test config and ignore generated artifacts

## Testing
- npm run test
- npm run lint *(fails: repository contains pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d159c0b3a08330b78f37c394089ef5